### PR TITLE
Extracts mapping private keys from the client constructor

### DIFF
--- a/example/push_transaction.dart
+++ b/example/push_transaction.dart
@@ -4,7 +4,7 @@ main() {
   EOSClient client = EOSClient('http://127.0.0.1:8888', 'v1',
       privateKeys: ["5J9b3xMkbvcT6gYv2EpQ8FD4ZBjgypuNKwE1jxkd7Wd1DYzhk88"]);
 
-  //EOSClient client = EOSClient('http://127.0.0.1:8888', 'v1');
+  //privateKeys can also be set after client was constructed, as following
   //client.privateKeys = ["5J9b3xMkbvcT6gYv2EpQ8FD4ZBjgypuNKwE1jxkd7Wd1DYzhk88"];
 
   List<Authorization> auth = [

--- a/example/push_transaction.dart
+++ b/example/push_transaction.dart
@@ -4,6 +4,9 @@ main() {
   EOSClient client = EOSClient('http://127.0.0.1:8888', 'v1',
       privateKeys: ["5J9b3xMkbvcT6gYv2EpQ8FD4ZBjgypuNKwE1jxkd7Wd1DYzhk88"]);
 
+  //EOSClient client = EOSClient('http://127.0.0.1:8888', 'v1');
+  //client.privateKeys = ["5J9b3xMkbvcT6gYv2EpQ8FD4ZBjgypuNKwE1jxkd7Wd1DYzhk88"];
+
   List<Authorization> auth = [
     Authorization()
       ..actor = 'bob'


### PR DESCRIPTION
As the title of this PR says, it extracts mapping private keys from the client constructor.

### Motivation
Creating an `EOSClient` instance once the private keys are known it is easy with the constructor. With the current setup, in cases where the client is already created and you need to add private keys to it to sign transactions (let's say after importing keys) you are forced to create another instance of the client since there's no way for you to do so.

This PR introduces extracts a public setter `privateKeys` which allows you to add private keys after a client instance has been created.

### Test
Tested in local testnet, both by setting up the private keys via the constructor and the setter, both work fine when pushing transactions.