### PR TITLE
Adding model for committed transaction 

### DIFF
--- a/lib/src/models/action.dart
+++ b/lib/src/models/action.dart
@@ -80,6 +80,31 @@ class Action {
   String toString() => this.toJson().toString();
 }
 
+@JsonSerializable(explicitToJson: true)
+class ActionArgs {
+  @JsonKey(name: 'from')
+  String fromAccount;
+
+  @JsonKey(name: 'to')
+  String toAccount;
+
+  @JsonKey(name: 'quantity')
+  String quantity;
+
+  @JsonKey(name: 'memo')
+  String memo;
+
+  ActionArgs();
+
+  factory ActionArgs.fromJson(Map<String, dynamic> json) =>
+      _$ActionArgsFromJson(json);
+
+  Map<String, dynamic> toJson() => _$ActionArgsToJson(this);
+
+  @override
+  String toString() => this.toJson().toString();
+}
+
 @JsonSerializable()
 class ActionReceipt with ConversionHelper {
   @JsonKey(name: 'receiver')

--- a/lib/src/models/action.g.dart
+++ b/lib/src/models/action.g.dart
@@ -70,6 +70,22 @@ Map<String, dynamic> _$ActionToJson(Action instance) => <String, dynamic>{
       'data': instance.data
     };
 
+ActionArgs _$ActionArgsFromJson(Map<String, dynamic> json) {
+  return ActionArgs()
+    ..fromAccount = json['from'] as String
+    ..toAccount = json['to'] as String
+    ..quantity = json['quantity'] as String
+    ..memo = json['memo'] as String;
+}
+
+Map<String, dynamic> _$ActionArgsToJson(ActionArgs instance) =>
+    <String, dynamic>{
+      'from': instance.fromAccount,
+      'to': instance.toAccount,
+      'quantity': instance.quantity,
+      'memo': instance.memo
+    };
+
 ActionReceipt _$ActionReceiptFromJson(Map<String, dynamic> json) {
   return ActionReceipt()
     ..receiver = json['receiver'] as String

--- a/lib/src/models/transaction.dart
+++ b/lib/src/models/transaction.dart
@@ -1,4 +1,5 @@
 import 'dart:typed_data';
+
 import 'package:json_annotation/json_annotation.dart';
 
 import './action.dart';
@@ -136,4 +137,63 @@ class Transaction {
     transactionType.serialize(transactionType, buffer, this.toJson());
     return buffer.asUint8List();
   }
+}
+
+@JsonSerializable()
+class TransactionCommitted {
+  @JsonKey(name: 'transaction_id')
+  String id;
+
+  @JsonKey(name: 'processed')
+  TransactionProcessed processed;
+
+  TransactionCommitted();
+
+  factory TransactionCommitted.fromJson(Map<String, dynamic> json) =>
+      _$TransactionCommittedFromJson(json);
+
+  Map<String, dynamic> toJson() => _$TransactionCommittedToJson(this);
+
+  @override
+  String toString() => this.toJson().toString();
+}
+
+@JsonSerializable()
+class TransactionProcessed with ConversionHelper {
+  @JsonKey(name: 'id')
+  String id;
+
+  @JsonKey(name: 'block_num', fromJson: ConversionHelper.getIntFromJson)
+  int blockNum;
+
+  @JsonKey(name: 'block_time')
+  String blockTime;
+
+  @JsonKey(name: 'producer_block_id', fromJson: ConversionHelper.getIntFromJson)
+  int producerBlockId;
+
+  @JsonKey(name: 'receipt')
+  TransactionReceipt receipt;
+
+  @JsonKey(name: 'elapsed', fromJson: ConversionHelper.getIntFromJson)
+  int elapsed;
+
+  @JsonKey(name: 'net_usage', fromJson: ConversionHelper.getIntFromJson)
+  int netUsage;
+
+  @JsonKey(name: 'scheduled')
+  bool scheduled;
+
+  @JsonKey(name: 'action_traces')
+  List<Object> actionTraces;
+
+  TransactionProcessed();
+
+  factory TransactionProcessed.fromJson(Map<String, dynamic> json) =>
+      _$TransactionProcessedFromJson(json);
+
+  Map<String, dynamic> toJson() => _$TransactionProcessedToJson(this);
+
+  @override
+  String toString() => this.toJson().toString();
 }

--- a/lib/src/models/transaction.dart
+++ b/lib/src/models/transaction.dart
@@ -167,7 +167,7 @@ class TransactionProcessed with ConversionHelper {
   int blockNum;
 
   @JsonKey(name: 'block_time')
-  String blockTime;
+  DateTime blockTime;
 
   @JsonKey(name: 'producer_block_id', fromJson: ConversionHelper.getIntFromJson)
   int producerBlockId;
@@ -185,7 +185,7 @@ class TransactionProcessed with ConversionHelper {
   bool scheduled;
 
   @JsonKey(name: 'action_traces')
-  List<Object> actionTraces;
+  List<ActionWithReceipt> actionTraces;
 
   TransactionProcessed();
 

--- a/lib/src/models/transaction.g.dart
+++ b/lib/src/models/transaction.g.dart
@@ -131,7 +131,9 @@ TransactionProcessed _$TransactionProcessedFromJson(Map<String, dynamic> json) {
     ..blockNum = json['block_num'] == null
         ? null
         : ConversionHelper.getIntFromJson(json['block_num'])
-    ..blockTime = json['block_time'] as String
+    ..blockTime = json['block_time'] == null
+        ? null
+        : DateTime.parse(json['block_time'] as String)
     ..producerBlockId = json['producer_block_id'] == null
         ? null
         : ConversionHelper.getIntFromJson(json['producer_block_id'])
@@ -145,7 +147,11 @@ TransactionProcessed _$TransactionProcessedFromJson(Map<String, dynamic> json) {
         ? null
         : ConversionHelper.getIntFromJson(json['net_usage'])
     ..scheduled = json['scheduled'] as bool
-    ..actionTraces = json['action_traces'] as List;
+    ..actionTraces = (json['action_traces'] as List)
+        ?.map((e) => e == null
+            ? null
+            : ActionWithReceipt.fromJson(e as Map<String, dynamic>))
+        ?.toList();
 }
 
 Map<String, dynamic> _$TransactionProcessedToJson(
@@ -153,7 +159,7 @@ Map<String, dynamic> _$TransactionProcessedToJson(
     <String, dynamic>{
       'id': instance.id,
       'block_num': instance.blockNum,
-      'block_time': instance.blockTime,
+      'block_time': instance.blockTime?.toIso8601String(),
       'producer_block_id': instance.producerBlockId,
       'receipt': instance.receipt,
       'elapsed': instance.elapsed,

--- a/lib/src/models/transaction.g.dart
+++ b/lib/src/models/transaction.g.dart
@@ -108,3 +108,56 @@ Map<String, dynamic> _$TransactionToJson(Transaction instance) =>
       'signatures': instance.signatures,
       'context_free_data': instance.contextFreeData
     };
+
+TransactionCommitted _$TransactionCommittedFromJson(Map<String, dynamic> json) {
+  return TransactionCommitted()
+    ..id = json['transaction_id'] as String
+    ..processed = json['processed'] == null
+        ? null
+        : TransactionProcessed.fromJson(
+            json['processed'] as Map<String, dynamic>);
+}
+
+Map<String, dynamic> _$TransactionCommittedToJson(
+        TransactionCommitted instance) =>
+    <String, dynamic>{
+      'transaction_id': instance.id,
+      'processed': instance.processed
+    };
+
+TransactionProcessed _$TransactionProcessedFromJson(Map<String, dynamic> json) {
+  return TransactionProcessed()
+    ..id = json['id'] as String
+    ..blockNum = json['block_num'] == null
+        ? null
+        : ConversionHelper.getIntFromJson(json['block_num'])
+    ..blockTime = json['block_time'] as String
+    ..producerBlockId = json['producer_block_id'] == null
+        ? null
+        : ConversionHelper.getIntFromJson(json['producer_block_id'])
+    ..receipt = json['receipt'] == null
+        ? null
+        : TransactionReceipt.fromJson(json['receipt'] as Map<String, dynamic>)
+    ..elapsed = json['elapsed'] == null
+        ? null
+        : ConversionHelper.getIntFromJson(json['elapsed'])
+    ..netUsage = json['net_usage'] == null
+        ? null
+        : ConversionHelper.getIntFromJson(json['net_usage'])
+    ..scheduled = json['scheduled'] as bool
+    ..actionTraces = json['action_traces'] as List;
+}
+
+Map<String, dynamic> _$TransactionProcessedToJson(
+        TransactionProcessed instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'block_num': instance.blockNum,
+      'block_time': instance.blockTime,
+      'producer_block_id': instance.producerBlockId,
+      'receipt': instance.receipt,
+      'elapsed': instance.elapsed,
+      'net_usage': instance.netUsage,
+      'scheduled': instance.scheduled,
+      'action_traces': instance.actionTraces
+    };

--- a/test/models/transaction_test.dart
+++ b/test/models/transaction_test.dart
@@ -49,5 +49,26 @@ void main() {
       expect(transaction.traces[0].producerBlockId,
           '02a07f3e8e112558b58e7027ae614336cf77b45980df9693219f77e7a2d0349e');
     });
+
+    test('Transaction Commited', () {
+      String transactionStr =
+          File('./test/models/transaction_test_data3.json').readAsStringSync();
+      Map<String, dynamic> transactionJson = json.decode(transactionStr);
+      TransactionCommitted transaction =
+          TransactionCommitted.fromJson(transactionJson);
+
+      expect(transaction.id,
+          '91b55122107079cb4eafb165511bac77b8a790c3d4008c5f7cd7cfa1236c0876');
+      expect(transaction.processed.blockNum, 729864);
+      expect(transaction.processed.blockTime, "2019-11-14T08:10:37.500");
+      expect(transaction.processed.producerBlockId, null);
+      expect(transaction.processed.receipt.status, "executed");
+      expect(transaction.processed.receipt.cpuUsageUs, 384);
+      expect(transaction.processed.receipt.netUsageWords, 16);
+      expect(transaction.processed.elapsed, 384);
+      expect(transaction.processed.netUsage, 128);
+      expect(transaction.processed.scheduled, false);
+      expect(transaction.processed.actionTraces.isNotEmpty, true);
+    });
   });
 }

--- a/test/models/transaction_test.dart
+++ b/test/models/transaction_test.dart
@@ -1,5 +1,5 @@
-import 'dart:io';
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:eosdart/eosdart.dart';
 import 'package:test/test.dart';
@@ -60,15 +60,21 @@ void main() {
       expect(transaction.id,
           '91b55122107079cb4eafb165511bac77b8a790c3d4008c5f7cd7cfa1236c0876');
       expect(transaction.processed.blockNum, 729864);
-      expect(transaction.processed.blockTime, "2019-11-14T08:10:37.500");
+      expect(transaction.processed.blockTime,
+          DateTime(2019, 11, 14, 8, 10, 37, 500));
       expect(transaction.processed.producerBlockId, null);
-      expect(transaction.processed.receipt.status, "executed");
+      expect(transaction.processed.receipt.status, 'executed');
       expect(transaction.processed.receipt.cpuUsageUs, 384);
       expect(transaction.processed.receipt.netUsageWords, 16);
       expect(transaction.processed.elapsed, 384);
       expect(transaction.processed.netUsage, 128);
       expect(transaction.processed.scheduled, false);
       expect(transaction.processed.actionTraces.isNotEmpty, true);
+      expect(transaction.processed.actionTraces.first.action.name, 'transfer');
+      expect(transaction.processed.actionTraces.first.action.data.toString(),
+          '{from: account1, to: account2, quantity: 1.00000000 EOS, memo: }');
+      expect(transaction.processed.actionTraces.first.action.account,
+          'eosio.token');
     });
   });
 }

--- a/test/models/transaction_test_data3.json
+++ b/test/models/transaction_test_data3.json
@@ -1,0 +1,172 @@
+{
+  "transaction_id": "91b55122107079cb4eafb165511bac77b8a790c3d4008c5f7cd7cfa1236c0876",
+  "processed": {
+    "id": "91b55122107079cb4eafb165511bac77b8a790c3d4008c5f7cd7cfa1236c0876",
+    "block_num": 729864,
+    "block_time": "2019-11-14T08:10:37.500",
+    "producer_block_id": null,
+    "receipt": {
+      "status": "executed",
+      "cpu_usage_us": 384,
+      "net_usage_words": 16
+    },
+    "elapsed": 384,
+    "net_usage": 128,
+    "scheduled": false,
+    "action_traces": [
+      {
+        "action_ordinal": 1,
+        "creator_action_ordinal": 0,
+        "closest_unnotified_ancestor_action_ordinal": 0,
+        "receipt": {
+          "receiver": "eosio.token",
+          "act_digest": "ad1d4e88a882fd1e43ecdb44dc2fd70b2387146ed96aa88c6276c894e23eba1e",
+          "global_sequence": 1302793,
+          "recv_sequence": 650832,
+          "auth_sequence": [
+            [
+              "account1",
+              106
+            ]
+          ],
+          "code_sequence": 27,
+          "abi_sequence": 1
+        },
+        "receiver": "eosio.token",
+        "act": {
+          "account": "eosio.token",
+          "name": "transfer",
+          "authorization": [
+            {
+              "actor": "account1",
+              "permission": "active"
+            }
+          ],
+          "data": {
+            "from": "account1",
+            "to": "account2",
+            "quantity": "1.00000000 EOS",
+            "memo": ""
+          },
+          "hex_data": "0000d00a5ce5b6790000d00ae0abd23400e1f50500000000084353480000000000"
+        },
+        "context_free": false,
+        "elapsed": 155,
+        "console": "",
+        "trx_id": "91b55122107079cb4eafb165511bac77b8a790c3d4008c5f7cd7cfa1236c0876",
+        "block_num": 729864,
+        "block_time": "2019-11-14T08:10:37.500",
+        "producer_block_id": null,
+        "account_ram_deltas": [
+          {
+            "account": "eosio.token",
+            "delta": 878
+          }
+        ],
+        "except": null,
+        "error_code": null,
+        "inline_traces": [
+          {
+            "action_ordinal": 2,
+            "creator_action_ordinal": 1,
+            "closest_unnotified_ancestor_action_ordinal": 1,
+            "receipt": {
+              "receiver": "account1",
+              "act_digest": "ad1d4e88a882fd1e43ecdb44dc2fd70b2387146ed96aa88c6276c894e23eba1e",
+              "global_sequence": 1302794,
+              "recv_sequence": 39,
+              "auth_sequence": [
+                [
+                  "account1",
+                  107
+                ]
+              ],
+              "code_sequence": 27,
+              "abi_sequence": 1
+            },
+            "receiver": "account1",
+            "act": {
+              "account": "eosio.token",
+              "name": "transfer",
+              "authorization": [
+                {
+                  "actor": "account1",
+                  "permission": "active"
+                }
+              ],
+              "data": {
+                "from": "account1",
+                "to": "account2",
+                "quantity": "1.00000000 EOS",
+                "memo": ""
+              },
+              "hex_data": "0000d00a5ce5b6790000d00ae0abd23400e1f50500000000084353480000000000"
+            },
+            "context_free": false,
+            "elapsed": 4,
+            "console": "",
+            "trx_id": "91b55122107079cb4eafb165511bac77b8a790c3d4008c5f7cd7cfa1236c0876",
+            "block_num": 729864,
+            "block_time": "2019-11-14T08:10:37.500",
+            "producer_block_id": null,
+            "account_ram_deltas": [],
+            "except": null,
+            "error_code": null,
+            "inline_traces": []
+          },
+          {
+            "action_ordinal": 3,
+            "creator_action_ordinal": 1,
+            "closest_unnotified_ancestor_action_ordinal": 1,
+            "receipt": {
+              "receiver": "account2",
+              "act_digest": "ad1d4e88a882fd1e43ecdb44dc2fd70b2387146ed96aa88c6276c894e23eba1e",
+              "global_sequence": 1302795,
+              "recv_sequence": 37,
+              "auth_sequence": [
+                [
+                  "account1",
+                  108
+                ]
+              ],
+              "code_sequence": 27,
+              "abi_sequence": 1
+            },
+            "receiver": "account2",
+            "act": {
+              "account": "eosio.token",
+              "name": "transfer",
+              "authorization": [
+                {
+                  "actor": "account1",
+                  "permission": "active"
+                }
+              ],
+              "data": {
+                "from": "account1",
+                "to": "account2",
+                "quantity": "1.00000000 EOS",
+                "memo": ""
+              },
+              "hex_data": "0000d00a5ce5b6790000d00ae0abd23400e1f50500000000084353480000000000"
+            },
+            "context_free": false,
+            "elapsed": 6,
+            "console": "",
+            "trx_id": "91b55122107079cb4eafb165511bac77b8a790c3d4008c5f7cd7cfa1236c0876",
+            "block_num": 729864,
+            "block_time": "2019-11-14T08:10:37.500",
+            "producer_block_id": null,
+            "account_ram_deltas": [],
+            "except": null,
+            "error_code": null,
+            "inline_traces": []
+          }
+        ]
+      }
+    ],
+    "account_ram_delta": null,
+    "except": null,
+    "error_code": null
+  }
+}


### PR DESCRIPTION
This PR adds a model for handling the successful response when committing a transaction to the blockchain. Two classes where created: `TransactionCommitted` and `TransactionProcessed`, fetching the most interesting fields in the response.

### Testing
Added a test parsing the response in `transaction_test_data3.json`.