### PR TITLE
handle any amount

### DIFF
--- a/lib/src/numeric.dart
+++ b/lib/src/numeric.dart
@@ -87,7 +87,7 @@ Uint8List signedDecimalToBinary(int size, String s) {
 /// Convert `bignum` to an unsigned decimal number
 /// @param minDigits 0-pad result to this many digits
 String binaryToDecimal(Uint8List bignum, {minDigits = 1}) {
-  var result = List.filled(minDigits, '0'.codeUnitAt(0));
+  var result = List.filled(minDigits, '0'.codeUnitAt(0), growable: true);
   for (var i = bignum.length - 1; i >= 0; --i) {
     var carry = bignum[i];
     for (var j = 0; j < result.length; ++j) {


### PR DESCRIPTION
Bug: Some amounts of assets would cause an exception

Fix: Make the list growable...

The error message was something along the lines of "cannot add to fixed length list" and happened when "carry" was != 0 at the very last number, when something would be added to the list that would grow it.

Example ESR that would cause this bug:
```
esr:gmNgYmBY1mTC_MoglIGBIVzX5uxZRkYGCGCC0oowAYOVp9OsViaXvJASBPNZQnz8g0EMoAIA
```

I tried to find unit test coverage of this issue but this really only happens when serializing, then de-serializing data, and there seem to be no unit tests to cover that in the code. Maybe I missed it? If there are tests for serializing/deserializing this case should be added. Asset amount that caused the crash was "112.1000 SEEDS"