### PR TITLE
Bugfix/serializations

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -27,8 +27,8 @@ class EOSClient {
   Map<String, ecc.EOSPrivateKey> keys = Map();
 
   /// Converts abi files between binary and structured form (`abi.abi.json`) */
-  late Map<String, Type> abiTypes;
-  late Map<String, Type> transactionTypes;
+  late Map<String?, Type> abiTypes;
+  late Map<String?, Type> transactionTypes;
 
   /// Construct the EOS client from eos node URL
   EOSClient(
@@ -284,7 +284,7 @@ class EOSClient {
       {bool reload = false}) async {
     var abi = await getRawAbi(accountName);
     var types = ser.getTypesFromAbi(ser.createInitialTypes(), abi.abi!);
-    var actions = new Map<String, Type>();
+    var actions = new Map<String?, Type>();
     for (var act in abi.abi!.actions!) {
       actions[act.name] = ser.getType(types, act.type);
     }

--- a/lib/src/eosdart_base.dart
+++ b/lib/src/eosdart_base.dart
@@ -54,9 +54,9 @@ class Type {
 }
 
 class Contract {
-  Map<String, Type> actions;
+  Map<String?, Type> actions;
 
-  Map<String, Type> types;
+  Map<String?, Type> types;
 
   Contract(this.types, this.actions);
 }

--- a/lib/src/models/abi.dart
+++ b/lib/src/models/abi.dart
@@ -50,7 +50,7 @@ class AbiResp with ConversionHelper {
 
   /// Decodes an abi as Uint8List into json. */
   static Abi? _rawAbiToJson(Uint8List rawAbi) {
-    Map<String, Type> abiTypes = ser.getTypesFromAbi(
+    Map<String?, Type> abiTypes = ser.getTypesFromAbi(
         ser.createInitialTypes(), Abi.fromJson(json.decode(abiJson)));
     try {
       var buffer = ser.SerialBuffer(rawAbi);

--- a/lib/src/numeric.dart
+++ b/lib/src/numeric.dart
@@ -1,12 +1,14 @@
+// ignore_for_file: parameter_assignments, prefer_final_locals, prefer_interpolation_to_compose_strings
 import 'dart:typed_data';
 import 'package:pointycastle/pointycastle.dart';
 
 /// @module Numeric
 
-var base58Chars = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
-var base64Chars =
+String base58Chars = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+String base64Chars =
     'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
 
+// ignore: non_constant_identifier_names
 List<int> create_base58_map() {
   var base58M = List.filled(256, -1);
   for (var i = 0; i < base58Chars.length; ++i) {
@@ -17,6 +19,7 @@ List<int> create_base58_map() {
 
 final base58Map = create_base58_map();
 
+// ignore: non_constant_identifier_names
 List<int> create_base64_map() {
   var base64M = List.filled(256, -1);
   for (var i = 0; i < base64Chars.length; ++i) {
@@ -86,7 +89,7 @@ Uint8List signedDecimalToBinary(int size, String s) {
 
 /// Convert `bignum` to an unsigned decimal number
 /// @param minDigits 0-pad result to this many digits
-String binaryToDecimal(Uint8List bignum, {minDigits = 1}) {
+String binaryToDecimal(Uint8List bignum, {int minDigits = 1}) {
   var result = List.filled(minDigits, '0'.codeUnitAt(0), growable: true);
   for (var i = bignum.length - 1; i >= 0; --i) {
     var carry = bignum[i];
@@ -117,7 +120,7 @@ String signedBinaryToDecimal(Uint8List bignum, {int minDigits = 1}) {
 /// Convert an unsigned base-58 number in `s` to a bignum
 /// @param size bignum size (bytes)
 Uint8List base58ToBinary(int size, String s) {
-  var result = new Uint8List(size);
+  var result = Uint8List(size);
   for (var i = 0; i < s.length; ++i) {
     var carry = base58Map[s.codeUnitAt(i)];
     if (carry < 0) {
@@ -137,9 +140,9 @@ Uint8List base58ToBinary(int size, String s) {
 
 /// Convert `bignum` to a base-58 number
 /// @param minDigits 0-pad result to this many digits
-String binaryToBase58(Uint8List bignum, {minDigits = 1}) {
+String binaryToBase58(Uint8List bignum, {int minDigits = 1}) {
   var result = <int>[];
-  for (var byte in bignum) {
+  for (final byte in bignum) {
     var carry = byte;
     for (var j = 0; j < result.length; ++j) {
       var x = (base58Map[result[j]] << 8) + carry;
@@ -151,7 +154,7 @@ String binaryToBase58(Uint8List bignum, {minDigits = 1}) {
       carry = (carry ~/ 58) | 0;
     }
   }
-  for (var byte in bignum) {
+  for (final byte in bignum) {
     if (byte != 0) {
       break;
     } else {
@@ -179,7 +182,7 @@ Uint8List base64ToBinary(String s) {
       bytes -= 1;
     }
   }
-  var result = new Uint8List(bytes);
+  var result = Uint8List(bytes);
 
   for (var group = 0; group < groups; ++group) {
     var digit0 = base64Map[s.codeUnitAt(group * 4 + 0)];
@@ -204,13 +207,13 @@ enum KeyType {
 }
 
 /// Public key data size, excluding type field
-var publicKeyDataSize = 33;
+int publicKeyDataSize = 33;
 
 /// Private key data size, excluding type field
-var privateKeyDataSize = 32;
+int privateKeyDataSize = 32;
 
 /// Signature data size, excluding type field
-var signatureDataSize = 65;
+int signatureDataSize = 65;
 
 /// Public key, private key, or signature in binary form
 class IKey {
@@ -221,7 +224,7 @@ class IKey {
 }
 
 Uint8List digestSuffixRipemd160(Uint8List data, String suffix) {
-  var d = new Uint8List(data.length + suffix.length);
+  var d = Uint8List(data.length + suffix.length);
   for (var i = 0; i < data.length; ++i) {
     d[i] = data[i];
   }
@@ -241,20 +244,20 @@ Uint8List digestSha256X2(Uint8List data) {
 
 IKey stringToKey(String s, KeyType type, int size, String suffix) {
   var whole = base58ToBinary(size + 4, s);
-  var result;
-  var digest;
+  IKey result;
+  Uint8List digest;
   if (suffix == '') {
     result = IKey(type, whole.sublist(1,size));
     digest = digestSha256X2(whole.sublist(0,size));
   } else {
     result = IKey(type, whole.sublist(0,size));
-    digest = digestSuffixRipemd160(result.data, suffix).toList();
+    digest = digestSuffixRipemd160(result.data, suffix);
   }
   if (digest[0] != whole[size + 0] ||
       digest[1] != whole[size + 1] ||
       digest[2] != whole[size + 2] ||
       digest[3] != whole[size + 3]) {
-    throw 'checksum doesn\'t match';
+    throw "checksum doesn't match";
   }
   return result;
 }
@@ -275,7 +278,7 @@ String keyToString(IKey key, String suffix, String prefix) {
 IKey stringToPublicKey(String s) {
   if (s.substring(0, 3) == 'EOS') {
     var whole = base58ToBinary(publicKeyDataSize + 4, s.substring(3));
-    var key = IKey(KeyType.k1, new Uint8List(publicKeyDataSize));
+    var key = IKey(KeyType.k1, Uint8List(publicKeyDataSize));
     for (var i = 0; i < publicKeyDataSize; ++i) {
       key.data[i] = whole[i];
     }
@@ -285,7 +288,7 @@ IKey stringToPublicKey(String s) {
         digest[1] != whole[34] ||
         digest[2] != whole[35] ||
         digest[3] != whole[36]) {
-      throw 'checksum doesn\'t match';
+      throw "checksum doesn't match";
     }
     return key;
   } else if (s.substring(0, 7) == 'PUB_K1_') {
@@ -298,7 +301,7 @@ IKey stringToPublicKey(String s) {
 }
 
 /// Convert `key` to string (base-58) form
-publicKeyToString(IKey key) {
+String publicKeyToString(IKey key) {
   if (key.type == KeyType.k1 && key.data.length == publicKeyDataSize) {
     return keyToString(key, 'K1', 'PUB_K1_');
   } else if (key.type == KeyType.r1 && key.data.length == publicKeyDataSize) {

--- a/lib/src/serialize.dart
+++ b/lib/src/serialize.dart
@@ -1085,7 +1085,7 @@ Map<String?, Type> getTypesFromAbi(Map<String, Type> initialTypes, Abi abi) {
           name: str.name,
           baseName: str.base,
           // ignore: avoid_redundant_argument_values
-          fields: str.fields?.map((item) => Field(name: item!.name, typeName: item.type, type: null)).toList(),
+          fields: str.fields?.map((item) => Field(name: item!.name!, typeName: item.type!, type: null)).toList(),
           serialize: serializeStruct,
           deserialize: deserializeStruct);
     }

--- a/lib/src/serialize.dart
+++ b/lib/src/serialize.dart
@@ -27,10 +27,10 @@ class SerializerState {
 /// Serialize and deserialize data */
 class SerialBuffer {
   /// Amount of valid data in `array` */
-  late int length;
+  int length = 0;
 
   /// Data in serialized (binary) form */
-  Uint8List? array;
+  Uint8List array;
 
   /// Current position while reading (deserializing) */
   int readPos = 0;
@@ -42,21 +42,21 @@ class SerialBuffer {
 
   SerialBuffer(this.array) {
     // array = array || new Uint8List(1024);
-    length = array != null ? array!.length : 0;
+    length = array != null ? array.length : 0;
     // textEncoder = textEncoder || new TextEncoder();
     // textDecoder = textDecoder || new TextDecoder('utf-8', { fatal: true });
   }
 
   /// Resize `array` if needed to have at least `size` bytes free */
   void reserve(int size) {
-    if (length + size <= array!.length) {
+    if (length + size <= array.length) {
       return;
     }
-    var l = array!.length;
+    var l = array.length;
     while (length + size > l) {
       l = (l * 1.5).ceil();
     }
-    var newArray = Uint8List.fromList(array!);
+    var newArray = Uint8List.fromList(array);
     array = newArray;
   }
 
@@ -72,7 +72,7 @@ class SerialBuffer {
 
   /// Return data with excess storage trimmed away */
   Uint8List asUint8List() {
-    return Uint8List.view(array!.buffer, array!.offsetInBytes, length);
+    return Uint8List.view(array.buffer, array.offsetInBytes, length);
   }
 
   /// Append bytes */
@@ -81,7 +81,7 @@ class SerialBuffer {
     // var t = Uint8List.view(array.buffer,0,array.length + v.length);
     // t.replaceRange(array.length, array.length + v.length - 1, v);
     // array = t;
-    var t = array!.toList();
+    var t = array.toList();
     t.addAll(v);
     array = Uint8List.fromList(t);
     length += v.length;
@@ -95,7 +95,7 @@ class SerialBuffer {
   /// Get a single byte */
   int get() {
     if (readPos < length) {
-      return array![readPos++];
+      return array[readPos++];
     }
     throw 'Read past end of buffer';
   }
@@ -114,7 +114,7 @@ class SerialBuffer {
       throw 'Read past end of buffer';
     }
     var result =
-        Uint8List.view(array!.buffer, array!.offsetInBytes + readPos, len);
+        Uint8List.view(array.buffer, array.offsetInBytes + readPos, len);
     readPos += len;
     return result;
   }
@@ -309,10 +309,11 @@ class SerialBuffer {
 
   /// Append a `symbol_code`. Unlike `symbol`, `symbol_code` doesn't include a precision. */
   void pushSymbolCode(String name) {
-    Uint8List a = Uint8List.fromList(utf8.encode(name));
-    while (a.length < 8) {
-      a.add(0);
+    final l = List<int>.from(utf8.encode(name));
+    while(l.length <8) {
+      l.add(0);
     }
+    Uint8List a = Uint8List.fromList(l);
     pushArray(a.sublist(0, 8));
   }
 
@@ -331,8 +332,8 @@ class SerialBuffer {
 
   /// Append a `symbol` */
   void pushSymbol(Symbol symbol) {
-    var a = [symbol.precision & 0xff];
-    a.addAll(utf8.encode(symbol.name));
+    var a = [symbol.precision! & 0xff];
+    a.addAll(utf8.encode(symbol.name!));
     while (a.length < 8) {
       a.add(0);
     }
@@ -393,13 +394,13 @@ class SerialBuffer {
   String getAsset() {
     var amount = getUint8List(8);
     var sym = getSymbol();
-    var s = numeric.signedBinaryToDecimal(amount, minDigits: sym.precision + 1);
+    var s = numeric.signedBinaryToDecimal(amount, minDigits: sym.precision! + 1);
     if (sym.precision != 0) {
-      s = s.substring(0, s.length - sym.precision) +
+      s = s.substring(0, s.length - sym.precision!) +
           '.' +
-          s.substring(s.length - sym.precision);
+          s.substring(s.length - sym.precision!);
     }
-    return s + ' ' + sym.name;
+    return s + ' ' + sym.name!;
   }
 
   /// Append a public key */
@@ -413,8 +414,7 @@ class SerialBuffer {
   String getPublicKey() {
     var type = get();
     var data = getUint8List(numeric.publicKeyDataSize);
-    return numeric
-        .publicKeyToString(numeric.IKey(type as numeric.KeyType, data));
+    return numeric.publicKeyToString(numeric.IKey(numeric.KeyType.values[type], data));
   }
 
   /// Append a private key */
@@ -428,8 +428,7 @@ class SerialBuffer {
   String getPrivateKey() {
     var type = get();
     var data = getUint8List(numeric.privateKeyDataSize);
-    return numeric
-        .privateKeyToString(numeric.IKey(type as numeric.KeyType, data));
+    return numeric.privateKeyToString(numeric.IKey(numeric.KeyType.values[type], data));
   }
 
   /// Append a signature */
@@ -443,35 +442,21 @@ class SerialBuffer {
   String getSignature() {
     var type = get();
     var data = getUint8List(numeric.signatureDataSize);
-    return numeric
-        .signatureToString(numeric.IKey(type as numeric.KeyType, data));
+    return numeric.signatureToString(numeric.IKey(numeric.KeyType.values[type], data));
   }
 } // SerialBuffer
 
-Type createType({
-  String name = '<missing name>',
-  String aliasOfName = "",
-  Type? arrayOf,
-  Type? optionalOf,
-  void Function(
-    Type self,
-    SerialBuffer buffer,
-    dynamic data, {
-    SerializerState? state,
-    required bool allowExtensions,
-  })?
-      serialize,
-  dynamic Function(
-    Type self,
-    SerialBuffer buffer, {
-    SerializerState? state,
-    required bool allowExtensions,
-  })?
-      deserialize,
-  String baseName: "",
-  List<Field> fields: const [],
-  Type? extensionOf,
-}) {
+Type createType(
+    {String? name = '<missing name>',
+    String? aliasOfName = "",
+    Type? arrayOf,
+    Type? optionalOf,
+    void Function(Type self, SerialBuffer buffer, Object data, {SerializerState state, bool allowExtensions})?
+        serialize,
+    Object? Function(Type self, SerialBuffer buffer, {SerializerState? state, bool? allowExtensions})? deserialize,
+    String? baseName: "",
+    List<Field>? fields: const [],
+    Type? extensionOf}) {
   var t = Type(
       aliasOfName: aliasOfName,
       name: name,
@@ -592,7 +577,7 @@ Symbol stringToSymbol(String s) {
 
 /// Convert `Symbol` to `string`. format: `precision,NAME`. */
 Future<String> symbolToString(Symbol s) async {
-  return s.precision.toString() + ',' + s.name;
+  return s.precision.toString() + ',' + s.name!;
 }
 
 /// Is this a supported ABI version? */
@@ -600,8 +585,7 @@ bool supportedAbiVersion(String version) {
   return version.startsWith('eosio::abi/1.');
 }
 
-void serializeStruct(Type self, SerialBuffer buffer, dynamic data,
-    {SerializerState? state, allowExtensions = true}) {
+void serializeStruct(Type self, SerialBuffer buffer, Object data, {SerializerState? state, allowExtensions = true}) {
   if (state == null) state = SerializerState();
   // try {
   if (self.base != null) {
@@ -609,26 +593,22 @@ void serializeStruct(Type self, SerialBuffer buffer, dynamic data,
         state: state, allowExtensions: allowExtensions);
   }
   Map dy = data as dynamic;
-  for (var field in self.fields) {
+  for (var field in self.fields!) {
     if (dy.containsKey(field.name)) {
       if (state.skippedBinaryExtension) {
-        throw 'unexpected ' + self.name + '.' + field.name;
+        throw 'unexpected ' + self.name! + '.' + field.name!;
       }
-      field.type!.serialize?.call(field.type, buffer, dy[field.name],
+      field.type!.serialize!.call(field.type, buffer, dy[field.name],
           state: state,
           allowExtensions:
-              allowExtensions && field == self.fields[self.fields.length - 1]);
+              allowExtensions && field == self.fields![self.fields!.length - 1]);
     } else {
       if (allowExtensions && field.type!.extensionOf != null) {
         state.skippedBinaryExtension = true;
+      } else if (field.type!.extensionOf != null) {
+        field.type!.serialize!(field.type, buffer, dy[field.name], state: state);
       } else {
-        throw 'missing ' +
-            self.name +
-            '.' +
-            field.name +
-            ' (type=' +
-            field.type!.name +
-            ')';
+        throw 'missing ' + self.name! + '.' + field.name! + ' (type=' + field.type!.name! + ')';
       }
     }
   }
@@ -643,19 +623,16 @@ Object deserializeStruct(Type self, SerialBuffer buffer,
   try {
     var result;
     if (self.base != null) {
-      result = self.base!.deserialize?.call(self.base, buffer,
-          state: state, allowExtensions: allowExtensions);
+      result = self.base!.deserialize!(self.base, buffer, state: state, allowExtensions: allowExtensions);
     } else {
       result = {};
     }
-    for (var field in self.fields) {
-      if (allowExtensions &&
-          field.type!.extensionOf != null &&
-          !buffer.haveReadData()) {
+    for (var field in self.fields!) {
+      if (allowExtensions && field.type!.extensionOf != null && !buffer.haveReadData()) {
         state.skippedBinaryExtension = true;
       } else {
-        result[field.name] = field.type!.deserialize?.call(field.type, buffer,
-            state: state, allowExtensions: allowExtensions);
+        result[field.name] =
+            field.type!.deserialize!(field.type, buffer, state: state, allowExtensions: allowExtensions);
       }
     }
     return result;
@@ -669,347 +646,161 @@ Map<String, Type> createInitialTypes() {
   var result = {
     "bool": createType(
       name: 'bool',
-      serialize: (
-        Type self,
-        SerialBuffer buffer,
-        dynamic data, {
-        SerializerState? state,
-        required bool allowExtensions,
-      }) {
-        buffer.push([data ? 1 : 0]);
+      serialize: (Type self, SerialBuffer buffer, Object data,
+           {SerializerState? state, bool? allowExtensions}) {
+        buffer.push([data == true ? 1 : 0]);
       },
-      deserialize: (
-        Type self,
-        SerialBuffer buffer, {
-        SerializerState? state,
-        required bool allowExtensions,
-      }) {
-        return buffer.get();
+      deserialize: (Type self, SerialBuffer buffer, {SerializerState? state, bool? allowExtensions}) {
+        return buffer.get()!=0;
       },
     ),
     "uint8": createType(
       name: 'uint8',
-      serialize: (
-        Type self,
-        SerialBuffer buffer,
-        dynamic data, {
-        SerializerState? state,
-        required bool allowExtensions,
-      }) {
-        buffer.push([checkRange(data, (data as int) & 0xff)]);
+      serialize: (Type self, SerialBuffer buffer, Object data, {SerializerState? state, bool? allowExtensions}) {
+        buffer.push([checkRange(data as int, data & 0xff)]);
+
       },
-      deserialize: (
-        Type self,
-        SerialBuffer buffer, {
-        SerializerState? state,
-        required bool allowExtensions,
-      }) {
+      deserialize: (Type self, SerialBuffer buffer, {SerializerState? state, bool? allowExtensions}) {
         return buffer.get();
       },
     ),
     "int8": createType(
       name: 'int8',
-      serialize: (
-        Type self,
-        SerialBuffer buffer,
-        dynamic data, {
-        SerializerState? state,
-        required bool allowExtensions,
-      }) {
-        buffer.push([checkRange(data, (data as int) << 24 >> 24)]);
+      serialize: (Type self, SerialBuffer buffer, Object data, {SerializerState? state, bool? allowExtensions}) {
+        buffer.push([checkRange((data as int), data << 24 >> 24)]);
       },
-      deserialize: (
-        Type self,
-        SerialBuffer buffer, {
-        SerializerState? state,
-        required bool allowExtensions,
-      }) {
+      deserialize: (Type self, SerialBuffer buffer, {SerializerState? state, bool? allowExtensions}) {
         return buffer.get() << 24 >> 24;
       },
     ),
     "uint16": createType(
       name: 'uint16',
-      serialize: (
-        Type self,
-        SerialBuffer buffer,
-        dynamic data, {
-        SerializerState? state,
-        required bool allowExtensions,
-      }) {
-        buffer.pushUint16(checkRange(data, (data as int) & 0xffff));
+      serialize: (Type self, SerialBuffer buffer, Object data, {SerializerState? state, bool? allowExtensions}) {
+        buffer.pushUint16(checkRange(data as int, data & 0xffff));
+
       },
-      deserialize: (
-        Type self,
-        SerialBuffer buffer, {
-        SerializerState? state,
-        required bool allowExtensions,
-      }) {
+      deserialize: (Type self, SerialBuffer buffer, {SerializerState? state, bool? allowExtensions}) {
         return buffer.getUint16();
       },
     ),
     "int16": createType(
       name: 'int16',
-      serialize: (
-        Type self,
-        SerialBuffer buffer,
-        dynamic data, {
-        SerializerState? state,
-        required bool allowExtensions,
-      }) {
-        buffer.pushUint16(checkRange(data, (data as int) << 16 >> 16));
+      serialize: (Type self, SerialBuffer buffer, Object data, {SerializerState? state, bool? allowExtensions}) {
+        buffer.pushUint16(checkRange(data as int, data << 16 >> 16));
       },
-      deserialize: (
-        Type self,
-        SerialBuffer buffer, {
-        SerializerState? state,
-        required bool allowExtensions,
-      }) {
+      deserialize: (Type self, SerialBuffer buffer, {SerializerState? state, bool? allowExtensions}) {
         return buffer.getUint16() << 16 >> 16;
       },
     ),
     "uint32": createType(
       name: 'uint32',
-      serialize: (
-        Type self,
-        SerialBuffer buffer,
-        dynamic data, {
-        SerializerState? state,
-        required bool allowExtensions,
-      }) {
-        buffer.pushUint32(checkRange(data, (data as int) >> 0));
+      serialize: (Type self, SerialBuffer buffer, Object data, {SerializerState? state, bool? allowExtensions}) {
+        buffer.pushUint32(checkRange(data as int, data >> 0));
       },
-      deserialize: (
-        Type self,
-        SerialBuffer buffer, {
-        SerializerState? state,
-        required bool allowExtensions,
-      }) {
+      deserialize: (Type self, SerialBuffer buffer, {SerializerState? state, bool? allowExtensions}) {
         return buffer.getUint32();
       },
     ),
     "uint64": createType(
       name: 'uint64',
-      serialize: (
-        Type self,
-        SerialBuffer buffer,
-        dynamic data, {
-        SerializerState? state,
-        required bool allowExtensions,
-      }) {
-        buffer.pushArray(numeric.decimalToBinary(8, '' + data));
+      serialize: (Type self, SerialBuffer buffer, Object data, {SerializerState? state, bool? allowExtensions}) {
+        buffer.pushArray(numeric.decimalToBinary(8, '' + data.toString()));
       },
-      deserialize: (
-        Type self,
-        SerialBuffer buffer, {
-        SerializerState? state,
-        required bool allowExtensions,
-      }) {
+      deserialize: (Type self, SerialBuffer buffer, {SerializerState? state, bool? allowExtensions}) {
         return numeric.binaryToDecimal(buffer.getUint8List(8));
       },
     ),
     "int64": createType(
       name: 'int64',
-      serialize: (
-        Type self,
-        SerialBuffer buffer,
-        dynamic data, {
-        SerializerState? state,
-        required bool allowExtensions,
-      }) {
-        buffer.pushArray(numeric.signedDecimalToBinary(8, '' + data));
+      serialize: (Type self, SerialBuffer buffer, Object data, {SerializerState? state, bool? allowExtensions}) {
+        buffer.pushArray(numeric.signedDecimalToBinary(8, '' + data.toString()));
       },
-      deserialize: (
-        Type self,
-        SerialBuffer buffer, {
-        SerializerState? state,
-        required bool allowExtensions,
-      }) {
+      deserialize: (Type self, SerialBuffer buffer, {SerializerState? state, bool? allowExtensions}) {
         return numeric.signedBinaryToDecimal(buffer.getUint8List(8));
       },
     ),
     "int32": createType(
       name: 'int32',
-      serialize: (
-        Type self,
-        SerialBuffer buffer,
-        dynamic data, {
-        SerializerState? state,
-        required bool allowExtensions,
-      }) {
+      serialize: (Type self, SerialBuffer buffer, Object data, {SerializerState? state, bool? allowExtensions}) {
         buffer.pushUint32(checkRange(data as int, data | 0));
       },
-      deserialize: (
-        Type self,
-        SerialBuffer buffer, {
-        SerializerState? state,
-        required bool allowExtensions,
-      }) {
+      deserialize: (Type self, SerialBuffer buffer, {SerializerState? state, bool? allowExtensions}) {
         return buffer.getUint32() | 0;
       },
     ),
     "varuint32": createType(
       name: 'varuint32',
-      serialize: (
-        Type self,
-        SerialBuffer buffer,
-        dynamic data, {
-        SerializerState? state,
-        required bool allowExtensions,
-      }) {
-        buffer.pushVaruint32(checkRange(data, (data as int) >> 0));
+      serialize: (Type self, SerialBuffer buffer, Object data, {SerializerState? state, bool? allowExtensions}) {
+        buffer.pushVaruint32(checkRange(data as int, data >> 0));
       },
-      deserialize: (
-        Type self,
-        SerialBuffer buffer, {
-        SerializerState? state,
-        required bool allowExtensions,
-      }) {
+      deserialize: (Type self, SerialBuffer buffer, {SerializerState? state, bool? allowExtensions}) {
         return buffer.getVaruint32();
       },
     ),
     "varint32": createType(
       name: 'varint32',
-      serialize: (
-        Type self,
-        SerialBuffer buffer,
-        dynamic data, {
-        SerializerState? state,
-        required bool allowExtensions,
-      }) {
-        buffer.pushVarint32(checkRange(data, data == null ? 0 : data));
+      serialize: (Type self, SerialBuffer buffer, Object data, {SerializerState? state, bool? allowExtensions}) {
+        buffer.pushVarint32(checkRange(data as int, data == null ? 0 : data));
       },
-      deserialize: (
-        Type self,
-        SerialBuffer buffer, {
-        SerializerState? state,
-        required bool allowExtensions,
-      }) {
+      deserialize: (Type self, SerialBuffer buffer, {SerializerState? state, bool? allowExtensions}) {
         return buffer.getVarint32();
       },
     ),
     "uint128": createType(
       name: 'uint128',
-      serialize: (
-        Type self,
-        SerialBuffer buffer,
-        dynamic data, {
-        SerializerState? state,
-        required bool allowExtensions,
-      }) {
-        buffer.pushArray(numeric.decimalToBinary(16, '' + data));
+      serialize: (Type self, SerialBuffer buffer, Object data, {SerializerState? state, bool? allowExtensions}) {
+        buffer.pushArray(numeric.decimalToBinary(16, '' + (data as String)));
       },
-      deserialize: (
-        Type self,
-        SerialBuffer buffer, {
-        SerializerState? state,
-        required bool allowExtensions,
-      }) {
+      deserialize: (Type self, SerialBuffer buffer, {SerializerState? state, bool? allowExtensions}) {
         return numeric.binaryToDecimal(buffer.getUint8List(16));
       },
     ),
     "int128": createType(
       name: 'int128',
-      serialize: (
-        Type self,
-        SerialBuffer buffer,
-        dynamic data, {
-        SerializerState? state,
-        required bool allowExtensions,
-      }) {
-        buffer.pushArray(numeric.signedDecimalToBinary(16, '' + data));
+      serialize: (Type self, SerialBuffer buffer, Object data, {SerializerState? state, bool? allowExtensions}) {
+        buffer.pushArray(numeric.signedDecimalToBinary(16, '' + (data as String)));
       },
-      deserialize: (
-        Type self,
-        SerialBuffer buffer, {
-        SerializerState? state,
-        required bool allowExtensions,
-      }) {
+      deserialize: (Type self, SerialBuffer buffer, {SerializerState? state, bool? allowExtensions}) {
         return numeric.signedBinaryToDecimal(buffer.getUint8List(16));
       },
     ),
     "float32": createType(
       name: 'float32',
-      serialize: (
-        Type self,
-        SerialBuffer buffer,
-        dynamic data, {
-        SerializerState? state,
-        required bool allowExtensions,
-      }) {
-        buffer.pushFloat32(data);
+      serialize: (Type self, SerialBuffer buffer, Object data, {SerializerState? state, bool? allowExtensions}) {
+        buffer.pushFloat32(data as double);
       },
-      deserialize: (
-        Type self,
-        SerialBuffer buffer, {
-        SerializerState? state,
-        required bool allowExtensions,
-      }) {
+      deserialize: (Type self, SerialBuffer buffer, {SerializerState? state, bool? allowExtensions}) {
         return buffer.getFloat32();
       },
     ),
     "float64": createType(
       name: 'float64',
-      serialize: (
-        Type self,
-        SerialBuffer buffer,
-        dynamic data, {
-        SerializerState? state,
-        required bool allowExtensions,
-      }) {
-        buffer.pushFloat64(data);
+      serialize: (Type self, SerialBuffer buffer, Object data, {SerializerState? state, bool? allowExtensions}) {
+        buffer.pushFloat64(data as double);
       },
-      deserialize: (
-        Type self,
-        SerialBuffer buffer, {
-        SerializerState? state,
-        required bool allowExtensions,
-      }) {
+      deserialize: (Type self, SerialBuffer buffer, {SerializerState? state, bool? allowExtensions}) {
         return buffer.getFloat64();
       },
     ),
     "float128": createType(
       name: 'float128',
-      serialize: (
-        Type self,
-        SerialBuffer buffer,
-        dynamic data, {
-        SerializerState? state,
-        required bool allowExtensions,
-      }) {
-        buffer.pushUint8ListChecked(hexToUint8List(data), 16);
+      serialize: (Type self, SerialBuffer buffer, Object data, {SerializerState? state, bool? allowExtensions}) {
+        buffer.pushUint8ListChecked(hexToUint8List(data as String), 16);
       },
-      deserialize: (
-        Type self,
-        SerialBuffer buffer, {
-        SerializerState? state,
-        required bool allowExtensions,
-      }) {
+      deserialize: (Type self, SerialBuffer buffer, {SerializerState? state, bool? allowExtensions}) {
         return arrayToHex(buffer.getUint8List(16));
       },
     ),
     "bytes": createType(
       name: 'bytes',
-      serialize: (
-        Type self,
-        SerialBuffer buffer,
-        dynamic data, {
-        SerializerState? state,
-        required bool allowExtensions,
-      }) {
-        if (data is Uint8List) {
-          buffer.pushBytes(data.toList());
-        } else if (data is List) {
-          buffer.pushBytes(data.cast<int>());
+      serialize: (Type self, SerialBuffer buffer, Object data, {SerializerState? state, bool? allowExtensions}) {
+        if (data is Uint8List || data is List) {
+          buffer.pushBytes(data as List<int>);
         } else {
-          buffer.pushBytes(hexToUint8List(data));
+          buffer.pushBytes(hexToUint8List(data as String));
         }
       },
-      deserialize: (
-        Type self,
-        SerialBuffer buffer, {
-        SerializerState? state,
-        required bool allowExtensions,
-      }) {
+      deserialize: (Type self, SerialBuffer buffer, {SerializerState? state, bool? allowExtensions}) {
         if (state != null && state.options.bytesAsUint8List) {
           return buffer.getBytes();
         } else {
@@ -1019,282 +810,128 @@ Map<String, Type> createInitialTypes() {
     ),
     "string": createType(
       name: 'string',
-      serialize: (
-        Type self,
-        SerialBuffer buffer,
-        dynamic data, {
-        SerializerState? state,
-        required bool allowExtensions,
-      }) {
-        buffer.pushString(data);
+      serialize: (Type self, SerialBuffer buffer, Object data, {SerializerState? state, bool? allowExtensions}) {
+        buffer.pushString(data as String);
       },
-      deserialize: (
-        Type self,
-        SerialBuffer buffer, {
-        SerializerState? state,
-        required bool allowExtensions,
-      }) {
+      deserialize: (Type self, SerialBuffer buffer, {SerializerState? state, bool? allowExtensions}) {
         return buffer.getString();
       },
     ),
     "name": createType(
       name: 'name',
-      serialize: (
-        Type self,
-        SerialBuffer buffer,
-        dynamic data, {
-        SerializerState? state,
-        required bool allowExtensions,
-      }) {
-        buffer.pushName(data);
+      serialize: (Type self, SerialBuffer buffer, Object data, {SerializerState? state, bool? allowExtensions}) {
+        buffer.pushName(data as String);
       },
-      deserialize: (
-        Type self,
-        SerialBuffer buffer, {
-        SerializerState? state,
-        required bool allowExtensions,
-      }) {
+      deserialize: (Type self, SerialBuffer buffer, {SerializerState? state, bool? allowExtensions}) {
         return buffer.getName();
       },
     ),
     "time_point": createType(
       name: 'time_point',
-      serialize: (
-        Type self,
-        SerialBuffer buffer,
-        dynamic data, {
-        SerializerState? state,
-        required bool allowExtensions,
-      }) {
-        buffer.pushNumberAsUint64(dateToTimePoint(data));
+      serialize: (Type self, SerialBuffer buffer, Object data, {SerializerState? state, bool? allowExtensions}) {
+        buffer.pushNumberAsUint64(dateToTimePoint(data as String));
       },
-      deserialize: (
-        Type self,
-        SerialBuffer buffer, {
-        SerializerState? state,
-        required bool allowExtensions,
-      }) {
+      deserialize: (Type self, SerialBuffer buffer, {SerializerState? state, bool? allowExtensions}) {
         return timePointToDate(buffer.getUint64AsNumber());
       },
     ),
     "time_point_sec": createType(
       name: 'time_point_sec',
-      serialize: (
-        Type self,
-        SerialBuffer buffer,
-        dynamic data, {
-        SerializerState? state,
-        required bool allowExtensions,
-      }) {
-        var date = dateToTimePointSec(data);
+      serialize: (Type self, SerialBuffer buffer, Object data, {SerializerState? state, bool? allowExtensions}) {
+        var date = dateToTimePointSec(data as String);
         buffer.pushUint32(date);
       },
-      deserialize: (
-        Type self,
-        SerialBuffer buffer, {
-        SerializerState? state,
-        required bool allowExtensions,
-      }) {
+      deserialize: (Type self, SerialBuffer buffer, {SerializerState? state, bool? allowExtensions}) {
         return timePointSecToDate(buffer.getUint32());
       },
     ),
     "block_timestamp_type": createType(
       name: 'block_timestamp_type',
-      serialize: (
-        Type self,
-        SerialBuffer buffer,
-        dynamic data, {
-        SerializerState? state,
-        required bool allowExtensions,
-      }) {
-        buffer.pushUint32(dateToBlockTimestamp(data));
+      serialize: (Type self, SerialBuffer buffer, Object data, {SerializerState? state, bool? allowExtensions}) {
+        buffer.pushUint32(dateToBlockTimestamp(data as String));
       },
-      deserialize: (
-        Type self,
-        SerialBuffer buffer, {
-        SerializerState? state,
-        required bool allowExtensions,
-      }) {
+      deserialize: (Type self, SerialBuffer buffer, {SerializerState? state, bool? allowExtensions}) {
         return blockTimestampToDate(buffer.getUint32());
       },
     ),
     "symbol_code": createType(
       name: 'symbol_code',
-      serialize: (
-        Type self,
-        SerialBuffer buffer,
-        dynamic data, {
-        SerializerState? state,
-        required bool allowExtensions,
-      }) {
-        buffer.pushSymbolCode(data);
+      serialize: (Type self, SerialBuffer buffer, Object data, {SerializerState? state, bool? allowExtensions}) {
+        buffer.pushSymbolCode(data as String);
       },
-      deserialize: (
-        Type self,
-        SerialBuffer buffer, {
-        SerializerState? state,
-        required bool allowExtensions,
-      }) {
+      deserialize: (Type self, SerialBuffer buffer, {SerializerState? state, bool? allowExtensions}) {
         return buffer.getSymbolCode();
       },
     ),
     "symbol": createType(
       name: 'symbol',
-      serialize: (
-        Type self,
-        SerialBuffer buffer,
-        dynamic data, {
-        SerializerState? state,
-        required bool allowExtensions,
-      }) {
-        buffer.pushSymbol(stringToSymbol(data));
+      serialize: (Type self, SerialBuffer buffer, Object data, {SerializerState? state, bool? allowExtensions}) {
+        buffer.pushSymbol(stringToSymbol(data as String));
       },
-      deserialize: (
-        Type self,
-        SerialBuffer buffer, {
-        SerializerState? state,
-        required bool allowExtensions,
-      }) {
+      deserialize: (Type self, SerialBuffer buffer, {SerializerState? state, bool? allowExtensions}) {
         return symbolToString(buffer.getSymbol());
       },
     ),
     "asset": createType(
       name: 'asset',
-      serialize: (
-        Type self,
-        SerialBuffer buffer,
-        dynamic data, {
-        SerializerState? state,
-        required bool allowExtensions,
-      }) {
-        buffer.pushAsset(data);
+      serialize: (Type self, SerialBuffer buffer, Object data, {SerializerState? state, bool? allowExtensions}) {
+        buffer.pushAsset(data as String);
       },
-      deserialize: (
-        Type self,
-        SerialBuffer buffer, {
-        SerializerState? state,
-        required bool allowExtensions,
-      }) {
+      deserialize: (Type self, SerialBuffer buffer, {SerializerState? state, bool? allowExtensions}) {
         return buffer.getAsset();
       },
     ),
     "checksum160": createType(
       name: 'checksum160',
-      serialize: (
-        Type self,
-        SerialBuffer buffer,
-        dynamic data, {
-        SerializerState? state,
-        required bool allowExtensions,
-      }) {
-        buffer.pushUint8ListChecked(hexToUint8List(data), 20);
+      serialize: (Type self, SerialBuffer buffer, Object data, {SerializerState? state, bool? allowExtensions}) {
+        buffer.pushUint8ListChecked(hexToUint8List(data as String), 20);
       },
-      deserialize: (
-        Type self,
-        SerialBuffer buffer, {
-        SerializerState? state,
-        required bool allowExtensions,
-      }) {
+      deserialize: (Type self, SerialBuffer buffer, {SerializerState? state, bool? allowExtensions}) {
         return arrayToHex(buffer.getUint8List(20));
       },
     ),
     "checksum256": createType(
       name: 'checksum256',
-      serialize: (
-        Type self,
-        SerialBuffer buffer,
-        dynamic data, {
-        SerializerState? state,
-        required bool allowExtensions,
-      }) {
-        buffer.pushUint8ListChecked(hexToUint8List(data), 32);
+      serialize: (Type self, SerialBuffer buffer, Object data, {SerializerState? state, bool? allowExtensions}) {
+        buffer.pushUint8ListChecked(hexToUint8List(data as String), 32);
       },
-      deserialize: (
-        Type self,
-        SerialBuffer buffer, {
-        SerializerState? state,
-        required bool allowExtensions,
-      }) {
+      deserialize: (Type self, SerialBuffer buffer, {SerializerState? state, bool? allowExtensions}) {
         return arrayToHex(buffer.getUint8List(32));
       },
     ),
     "checksum512": createType(
       name: 'checksum512',
-      serialize: (
-        Type self,
-        SerialBuffer buffer,
-        dynamic data, {
-        SerializerState? state,
-        required bool allowExtensions,
-      }) {
-        buffer.pushUint8ListChecked(hexToUint8List(data), 64);
+      serialize: (Type self, SerialBuffer buffer, Object data, {SerializerState? state, bool? allowExtensions}) {
+        buffer.pushUint8ListChecked(hexToUint8List(data as String), 64);
       },
-      deserialize: (
-        Type self,
-        SerialBuffer buffer, {
-        SerializerState? state,
-        required bool allowExtensions,
-      }) {
+      deserialize: (Type self, SerialBuffer buffer, {SerializerState? state, bool? allowExtensions}) {
         return arrayToHex(buffer.getUint8List(64));
       },
     ),
     "public_key": createType(
       name: 'public_key',
-      serialize: (
-        Type self,
-        SerialBuffer buffer,
-        dynamic data, {
-        SerializerState? state,
-        required bool allowExtensions,
-      }) {
-        buffer.pushPublicKey(data);
+      serialize: (Type self, SerialBuffer buffer, Object data, {SerializerState? state, bool? allowExtensions}) {
+        buffer.pushPublicKey(data as String);
       },
-      deserialize: (
-        Type self,
-        SerialBuffer buffer, {
-        SerializerState? state,
-        required bool allowExtensions,
-      }) {
+      deserialize: (Type self, SerialBuffer buffer, {SerializerState? state, bool? allowExtensions}) {
         return buffer.getPublicKey();
       },
     ),
     "private_key": createType(
       name: 'private_key',
-      serialize: (
-        Type self,
-        SerialBuffer buffer,
-        dynamic data, {
-        SerializerState? state,
-        required bool allowExtensions,
-      }) {
-        buffer.pushPrivateKey(data);
+      serialize: (Type self, SerialBuffer buffer, Object data, {SerializerState? state, bool? allowExtensions}) {
+        buffer.pushPrivateKey(data as String);
       },
-      deserialize: (
-        Type self,
-        SerialBuffer buffer, {
-        SerializerState? state,
-        required bool allowExtensions,
-      }) {
+      deserialize: (Type self, SerialBuffer buffer, {SerializerState? state, bool? allowExtensions}) {
         return buffer.getPrivateKey();
       },
     ),
     "signature": createType(
       name: 'signature',
-      serialize: (
-        Type self,
-        SerialBuffer buffer,
-        dynamic data, {
-        SerializerState? state,
-        required bool allowExtensions,
-      }) {
-        buffer.pushSignature(data);
+      serialize: (Type self, SerialBuffer buffer, Object data, {SerializerState? state, bool? allowExtensions}) {
+        buffer.pushSignature(data as String);
       },
-      deserialize: (
-        Type self,
-        SerialBuffer buffer, {
-        SerializerState? state,
-        required bool allowExtensions,
-      }) {
+      deserialize: (Type self, SerialBuffer buffer, {SerializerState? state, bool? allowExtensions}) {
         return buffer.getSignature();
       },
     ),
@@ -1314,15 +951,15 @@ Map<String, Type> createInitialTypes() {
   return result;
 } // createInitialTypes()
 
-serializeVariant(Type self, SerialBuffer buffer, dynamic data,
-    {SerializerState? state, allowExtensions = true}) {
+
+serializeVariant(Type self, SerialBuffer buffer, Object data, {SerializerState? state, allowExtensions = true}) {
   if (state == null) state = SerializerState();
   if (!(data is List) || data.length != 2 || !(data[0] is String)) {
     throw 'expected variant: ["type", value]';
   }
-  var a = (data[0]) as String;
-  var b = (data[1]) as Object;
-  var i = self.fields.indexWhere((field) => field.name == a);
+  var a = ((data as List)[0]) as String;
+  var b = ((data as List)[1]) as Object;
+  var i = self.fields!.indexWhere((field) => field.name == a);
   if (i < 0) {
     throw 'type "$b" is not valid for variant';
   }
@@ -1335,24 +972,18 @@ deserializeVariant(Type self, SerialBuffer buffer,
     {SerializerState? state, allowExtensions = true}) {
   if (state == null) state = SerializerState();
   var i = buffer.getVaruint32();
-  if (i >= self.fields.length) {
+  if (i >= self.fields!.length) {
     throw 'type index $i is not valid for variant';
   }
-  var field = self.fields[i];
-  return [
-    field.name,
-    field.type!.deserialize?.call(field.type, buffer,
-        state: state, allowExtensions: allowExtensions)
-  ];
+  var field = self.fields![i];
+    return [field.name, field.type!.deserialize!(field.type, buffer, state: state, allowExtensions: allowExtensions)];
 }
 
-serializeArray(Type self, SerialBuffer buffer, dynamic data,
-    {SerializerState? state, allowExtensions = true}) {
+serializeArray(Type self, SerialBuffer buffer, Object data, {SerializerState? state, allowExtensions = true}) {
   if (state == null) state = SerializerState();
   buffer.pushVaruint32((data as List).length);
   for (var item in data) {
-    self.arrayOf!.serialize?.call(self.arrayOf, buffer, item,
-        state: state, allowExtensions: false);
+    self.arrayOf!.serialize!(self.arrayOf, buffer, item, state: state, allowExtensions: false);
   }
 }
 
@@ -1362,21 +993,18 @@ deserializeArray(Type self, SerialBuffer buffer,
   var len = buffer.getVaruint32();
   var result = [];
   for (var i = 0; i < len; ++i) {
-    result.add(self.arrayOf!.deserialize
-        ?.call(self.arrayOf, buffer, state: state, allowExtensions: false));
+    result.add(self.arrayOf!.deserialize!(self.arrayOf, buffer, state: state, allowExtensions: false));
   }
   return result;
 }
 
-serializeOptional(Type self, SerialBuffer buffer, dynamic data,
-    {SerializerState? state, allowExtensions = true}) {
+serializeOptional(Type self, SerialBuffer buffer, Object data, {SerializerState? state, allowExtensions = true}) {
   if (state == null) state = SerializerState();
   if (data == null) {
     buffer.push([0]);
   } else {
     buffer.push([1]);
-    self.optionalOf!.serialize?.call(self.optionalOf, buffer, data,
-        state: state, allowExtensions: allowExtensions);
+    self.optionalOf!.serialize!(self.optionalOf, buffer, data, state: state, allowExtensions: allowExtensions);
   }
 }
 
@@ -1384,37 +1012,33 @@ deserializeOptional(Type self, SerialBuffer buffer,
     {SerializerState? state, allowExtensions = true}) {
   if (state == null) state = SerializerState();
   if (buffer.get() != 0) {
-    return self.optionalOf!.deserialize?.call(self.optionalOf, buffer,
-        state: state, allowExtensions: allowExtensions);
+    return self.optionalOf!.deserialize!(self.optionalOf, buffer, state: state, allowExtensions: allowExtensions);
   } else {
     return null;
   }
 }
 
-serializeExtension(Type self, SerialBuffer buffer, dynamic data,
-    {SerializerState? state, allowExtensions = true}) {
+serializeExtension(Type self, SerialBuffer buffer, Object data, {SerializerState? state, allowExtensions = true}) {
   if (state == null) state = SerializerState();
-  self.extensionOf!.serialize?.call(self.extensionOf, buffer, data,
-      state: state, allowExtensions: allowExtensions);
+  self.extensionOf!.serialize!(self.extensionOf, buffer, data, state: state, allowExtensions: allowExtensions);
 }
 
 deserializeExtension(Type self, SerialBuffer buffer,
     {SerializerState? state, allowExtensions = true}) {
   if (state == null) state = SerializerState();
-  return self.extensionOf!.deserialize?.call(self.extensionOf, buffer,
-      state: state, allowExtensions: allowExtensions);
+  return self.extensionOf!.deserialize!(self.extensionOf, buffer, state: state, allowExtensions: allowExtensions);
 }
 
 /// Get type from `types` */
-Type getType(Map<String, Type> types, String name) {
+Type getType(Map<String?, Type> types, String? name) {
   var type = types[name];
-  if (type != null && type.aliasOfName.isNotEmpty) {
+  if (type != null && type.aliasOfName!.isNotEmpty) {
     return getType(types, type.aliasOfName);
   }
   if (type != null) {
     return type;
   }
-  if (name.endsWith('[]')) {
+  if (name!.endsWith('[]')) {
     return createType(
       name: name,
       arrayOf: getType(types, name.substring(0, name.length - 2)),
@@ -1445,46 +1069,38 @@ Type getType(Map<String, Type> types, String name) {
 /// @param initialTypes Set of types to build on.
 ///     In most cases, it's best to fill this from a fresh call to `getTypesFromAbi()`.
 
-Map<String, Type> getTypesFromAbi(Map<String, Type> initialTypes, Abi abi) {
-  var types = Map.from(initialTypes).cast<String, Type>();
+Map<String?, Type> getTypesFromAbi(Map<String, Type> initialTypes, Abi abi) {
+  var types = Map.from(initialTypes).cast<String?, Type>();
   if (abi.types != null) {
     for (var item in abi.types!) {
-      types[item.new_type_name] =
-          createType(name: item.new_type_name, aliasOfName: item.type);
+      types[item?.new_type_name] = createType(name: item?.new_type_name, aliasOfName: item?.type);
     }
   }
   if (abi.structs != null) {
     for (var str in abi.structs!) {
-      types[str.name!] = createType(
-          name: str.name!,
-          baseName: str.base ?? '',
-          fields: str.fields
-                  ?.map((item) =>
-                      Field(name: item.name, typeName: item.type, type: null))
-                  .toList() ??
-              [],
+      types[str!.name] = createType(
+          name: str.name,
+          baseName: str.base,
+          fields: str.fields?.map((item) => Field(name: item!.name, typeName: item.type, type: null)).toList(),
           serialize: serializeStruct,
           deserialize: deserializeStruct);
     }
   }
   if (abi.variants != null) {
     for (var v in abi.variants!) {
-      types[v.name!] = createType(
-        name: v.name!,
-        fields: v.types
-                ?.map((s) => Field(name: s, typeName: s, type: null))
-                .toList() ??
-            [],
+      types[v!.name] = createType(
+        name: v.name,
+        fields: v.types?.map((s) => Field(name: s, typeName: s, type: null)).toList(),
         serialize: serializeVariant,
         deserialize: deserializeVariant,
       );
     }
   }
   types.forEach((name, type) {
-    if (type.baseName.isNotEmpty) {
+    if (type.baseName!.isNotEmpty) {
       type.base = getType(types, type.baseName);
     }
-    for (var field in type.fields) {
+    for (var field in type.fields!) {
       field.type = getType(types, field.typeName);
     }
   });

--- a/lib/src/serialize.dart
+++ b/lib/src/serialize.dart
@@ -459,15 +459,15 @@ Type createType(
     List<Field>? fields = const [],
     Type? extensionOf}) {
   var t = Type(
-      aliasOfName: aliasOfName,
-      name: name,
+      aliasOfName: aliasOfName!,
+      name: name!,
       arrayOf: arrayOf,
       optionalOf: optionalOf,
       extensionOf: extensionOf,
       // ignore: avoid_redundant_argument_values
       base: null,
-      baseName: baseName,
-      fields: fields,
+      baseName: baseName!,
+      fields: fields!,
       serialize: serialize,
       deserialize: deserialize);
 

--- a/test/eosdart_test.dart
+++ b/test/eosdart_test.dart
@@ -1,7 +1,160 @@
+import 'dart:typed_data';
 import 'package:eosdart/eosdart.dart';
 import 'package:test/test.dart';
 
 void main() {
+  const verbose = false; 
+  group('public keys', () {
+    test('serialize k1 old style', ()  {
+      final keystring = 'EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV';
+      final sb = new SerialBuffer(new Uint8List(0));
+      sb.pushPublicKey(keystring);
+      final serialized = sb.asUint8List();
+
+      if(verbose) {
+        print("keystring: $keystring");
+        print("serialized: $serialized\n"+"   ${arrayToHex(serialized)}");
+      }
+      expect(serialized,
+          [0, 2, 192, 222, 210, 188, 31, 19, 5, 251, 15, 170, 197, 230, 192, 62,
+            227, 161, 146, 66, 52, 152, 84, 39, 182, 22, 124, 165, 105, 209, 61,
+            244, 53, 207]);
+    });
+    test('serialize k1 new style', ()  {
+      final keystring = 'PUB_K1_6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5BoDq63';
+      final sb = new SerialBuffer(new Uint8List(0));
+      sb.pushPublicKey(keystring);
+      final serialized = sb.asUint8List();
+
+      if(verbose) {
+        print("keystring: $keystring");
+        print("serialized: $serialized\n"+"   ${arrayToHex(serialized)}");
+      }
+      expect(serialized,
+          [0, 2, 192, 222, 210, 188, 31, 19, 5, 251, 15, 170, 197, 230, 192, 62,
+            227, 161, 146, 66, 52, 152, 84, 39, 182, 22, 124, 165, 105, 209, 61,
+            244, 53, 207]);
+    });
+    test('deserialize k1 new style', ()  {
+      final serialized = Uint8List.fromList([0, 2, 192, 222, 210, 188, 31, 19,
+        5, 251, 15, 170, 197, 230, 192, 62, 227, 161, 146, 66, 52, 152, 84, 39,
+        182, 22, 124, 165, 105, 209, 61, 244, 53, 207]);
+      final sb = new SerialBuffer(serialized);
+      final keystring = sb.getPublicKey();
+
+      if(verbose) {
+        print("keystring: $keystring");
+        print("serialized: $serialized\n"+"   ${arrayToHex(serialized)}");
+      }
+      expect(keystring, 'PUB_K1_6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5BoDq63');
+    });
+    test('serialize r1 new style', ()  {
+      final keystring = 'PUB_R1_6eMzJfDVWvzMTYAUWQ95JcpoY8vFL62pTFm6spim25n5wqtVWP';
+      final sb = new SerialBuffer(new Uint8List(0));
+      sb.pushPublicKey(keystring);
+      final serialized = sb.asUint8List();
+
+      if(verbose) {
+        print("keystring: $keystring");
+        print("serialized: $serialized\n"+"   ${arrayToHex(serialized)}");
+      }
+      expect(serialized,
+          [1, 2, 231, 80, 174, 4, 190, 33, 189, 1, 48, 165, 223, 203, 242,
+           125, 16, 95, 97, 223, 20, 206, 120, 17, 207, 107, 49, 24, 30,
+           7, 140, 39, 8, 36]);
+    });
+    test('deserialize r1 new style', ()  {
+      final serialized = Uint8List.fromList(
+        [1, 2, 231, 80, 174, 4, 190, 33, 189, 1, 48, 165, 223, 203, 242,
+           125, 16, 95, 97, 223, 20, 206, 120, 17, 207, 107, 49, 24, 30,
+           7, 140, 39, 8, 36]);
+      final sb = new SerialBuffer(serialized);
+      final keystring = sb.getPublicKey();
+
+      if(verbose) {
+        print("keystring: $keystring");
+        print("serialized: $serialized\n"+"   ${arrayToHex(serialized)}");
+      }
+      expect(keystring, 'PUB_R1_6eMzJfDVWvzMTYAUWQ95JcpoY8vFL62pTFm6spim25n5wqtVWP');
+    });
+
+  });
+
+  group('private keys', () {
+    test('serialize k1 old style', ()  {
+      final keystring = '5KQwrPbwdL6PhXujxW37FSSQZ1JiwsST4cqQzDeyXtP79zkvFD3';
+      final sb = new SerialBuffer(new Uint8List(0));
+      sb.pushPrivateKey(keystring);
+      final serialized = sb.asUint8List();
+
+      if(verbose) {
+        print("keystring: $keystring");
+        print("serialized: $serialized\n"+"   ${arrayToHex(serialized)}");
+      }
+      expect(serialized,
+          [0, 210, 101, 63, 247, 203, 178, 216, 255, 18, 154, 194, 126, 245,
+            120, 28, 230, 139, 37, 88, 196, 26, 116, 175, 31, 45, 220, 166, 53,
+            203, 238, 240, 125]);
+    });
+    test('serialize k1 new style', ()  {
+      final keystring = 'PVT_K1_2bfGi9rYsXQSXXTvJbDAPhHLQUojjaNLomdm3cEJ1XTzMqUt3V';
+      final sb = new SerialBuffer(new Uint8List(0));
+      sb.pushPrivateKey(keystring);
+      final serialized = sb.asUint8List();
+
+      if(verbose) {
+        print("keystring: $keystring");
+        print("serialized: $serialized\n"+"   ${arrayToHex(serialized)}");
+      }
+      expect(serialized,
+          [0, 210, 101, 63, 247, 203, 178, 216, 255, 18, 154, 194, 126, 245,
+            120, 28, 230, 139, 37, 88, 196, 26, 116, 175, 31, 45, 220, 166, 53,
+            203, 238, 240, 125]);
+    });
+    test('deserialize k1 new style', ()  {
+      final serialized = Uint8List.fromList([0, 210, 101, 63, 247, 203, 178,
+        216, 255, 18, 154, 194, 126, 245, 120, 28, 230, 139, 37, 88, 196,
+        26, 116, 175, 31, 45, 220, 166, 53, 203, 238, 240, 125]);
+      final sb = new SerialBuffer(serialized);
+      final keystring = sb.getPrivateKey();
+
+      if(verbose) {
+        print("keystring: $keystring");
+        print("serialized: $serialized\n"+"   ${arrayToHex(serialized)}");
+      }
+      expect(keystring, 'PVT_K1_2bfGi9rYsXQSXXTvJbDAPhHLQUojjaNLomdm3cEJ1XTzMqUt3V');
+    });
+    test('serialize r1 new style', ()  {
+      final keystring = 'PVT_R1_2JrJRQXEagWobhJbHWtP11muTWi5pgCJ6uXWhGKd2KcFBGF7mT';
+      final sb = new SerialBuffer(new Uint8List(0));
+      sb.pushPrivateKey(keystring);
+      final serialized = sb.asUint8List();
+
+      if(verbose) {
+        print("keystring: $keystring");
+        print("serialized: $serialized\n"+"   ${arrayToHex(serialized)}");
+      }
+      expect(serialized,
+          [1, 172, 58, 10, 48, 178, 188, 37, 15, 234, 129, 216, 243, 182,
+           68, 115, 41, 18, 206, 91, 223, 230, 199, 84, 66, 41, 110, 159,
+           117, 45, 189, 67, 43]);
+    });
+    test('deserialize r1 new style', ()  {
+      final serialized = Uint8List.fromList(
+        [1, 172, 58, 10, 48, 178, 188, 37, 15, 234, 129, 216, 243, 182,
+           68, 115, 41, 18, 206, 91, 223, 230, 199, 84, 66, 41, 110, 159,
+           117, 45, 189, 67, 43]);
+      final sb = new SerialBuffer(serialized);
+      final keystring = sb.getPrivateKey();
+
+      if(verbose) {
+        print("keystring: $keystring");
+        print("serialized: $serialized\n"+"   ${arrayToHex(serialized)}");
+      }
+      expect(keystring, 'PVT_R1_2JrJRQXEagWobhJbHWtP11muTWi5pgCJ6uXWhGKd2KcFBGF7mT');
+    });
+
+  });
   group('EOS Client', () {
     late EOSClient client;
 


### PR DESCRIPTION
This PR primarily backports serialization/deserialization fixes for a few data types, specifically `symbolcode`, `bool`, and public/private keys.

It also addresses most linter complaints.

This passes the unit tests without null-check failures. However the null safety treatment is embarrassingly _ad hoc_ and deserves a refactor.

Backported from https://github.com/JoinSEEDS/seeds_light_wallet/tree/rainbow_apk/lib/crypto/eosdart/src
