### PR TITLE
Bugfix/floats

### DIFF
--- a/lib/src/serialize.dart
+++ b/lib/src/serialize.dart
@@ -219,7 +219,9 @@ class SerialBuffer {
 
   // /** Get a `float32` */
   double getFloat32() {
-    return getUint8List(4).buffer.asFloat32List()[0];
+    var rp = readPos;
+    getUint8List(4);
+    return array.buffer.asByteData(rp).getFloat32(0, Endian.little);
   }
 
   // /** Append a `float64` */
@@ -229,7 +231,9 @@ class SerialBuffer {
 
   // /** Get a `float64` */
   double getFloat64() {
-    return getUint8List(8).buffer.asFloat64List()[0];
+    var rp = readPos;
+    getUint8List(8);
+    return array.buffer.asByteData(rp).getFloat64(0, Endian.little);
   }
 
   /// Append a `name` */

--- a/test/eosdart_test.dart
+++ b/test/eosdart_test.dart
@@ -4,6 +4,35 @@ import 'package:test/test.dart';
 
 void main() {
   const verbose = false; 
+  group('float32 & float64 serdes', () {
+    final double floatval = 3.141590118408203; // an exact float32
+    final sb = new SerialBuffer(new Uint8List(0));
+    test('serialize', ()  {
+      sb.push([15]); // misalign by pushing 1 arbitrary byte
+      sb.pushFloat32(floatval);
+      sb.pushFloat64(floatval);
+      final serialized = sb.asUint8List();
+
+      if(verbose) {
+        print("floatval: $floatval");
+        print("serialized: $serialized\n"+"   ${arrayToHex(serialized)}");
+      }
+      expect(serialized,
+          [15, 208, 15, 73, 64, 0, 0, 0, 0, 250, 33, 9, 64]);
+    });
+    test('deserialize', ()  {
+      sb.restartRead();
+      sb.get();
+      final v32 = sb.getFloat32();
+      final v64 = sb.getFloat64();
+      if(verbose) {
+        print("floatval32: $v32, floatval64: $v64");
+      }
+      expect([v32, v64],
+          [floatval, floatval]);
+    });
+  });
+  
   group('public keys', () {
     test('serialize k1 old style', ()  {
       final keystring = 'EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV';


### PR DESCRIPTION
The ByteBuffer.asFloatxxList() functions required 32- or 64-bit aligned buffer addresses. We can't guarantee alignment, so use ByteData.getFloatxx() methods instead.